### PR TITLE
Add sentry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,3 +49,13 @@ jobs:
           git-config-email: inbox@dragonfruit.network
           repository-name: dragonfruitnetwork/sakura-web
           token: ${{ steps.sakura-deploy-key.outputs.token }}
+          
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_ORG: dragonfruit
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          projects: sakura
+          version: ${{ github.ref_name }}
+          

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -13,6 +13,8 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.6" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.6" PrivateAssets="all" />
         <PackageReference Include="MudBlazor" Version="6.0.10" />
+        <PackageReference Include="Sentry.Serilog" Version="3.19.0" />
+        <PackageReference Include="Serilog" Version="2.11.0" />
         <PackageReference Include="SharpYaml" Version="1.9.2" />
     </ItemGroup>
 

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -15,6 +15,8 @@
         <PackageReference Include="MudBlazor" Version="6.0.10" />
         <PackageReference Include="Sentry.Serilog" Version="3.19.0" />
         <PackageReference Include="Serilog" Version="2.11.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+        <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0" />
         <PackageReference Include="SharpYaml" Version="1.9.2" />
     </ItemGroup>
 

--- a/DragonFruit.Sakura/Program.cs
+++ b/DragonFruit.Sakura/Program.cs
@@ -1,6 +1,7 @@
 // DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
+using System.Reflection;
 using DragonFruit.Data;
 using DragonFruit.Data.Serializers.SystemJson;
 using DragonFruit.Sakura.Wiki;
@@ -8,6 +9,9 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor;
 using MudBlazor.Services;
+using Serilog;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
 
 namespace DragonFruit.Sakura
 {
@@ -34,6 +38,23 @@ namespace DragonFruit.Sakura
             builder.Services.AddMudServices();
             builder.Services.AddSingleton<WikiRenderer>();
             builder.Services.AddSingleton<ApiClient, ApiClient<ApiSystemTextJsonSerializer>>();
+
+            var loggingConfig = new LoggerConfiguration()
+                                .MinimumLevel.Debug()
+                                .Enrich.WithProperty("InstanceId", Guid.NewGuid().ToString("D"))
+                                .WriteTo.BrowserConsole()
+                                .WriteTo.Sentry(o =>
+                                {
+                                    var version = Assembly.GetExecutingAssembly().GetName().Version;
+
+                                    o.MaxBreadcrumbs = 50;
+                                    o.MinimumEventLevel = LogEventLevel.Error;
+                                    o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                                    o.Release = version?.ToString(version.Build > 0 ? 3 : 2);
+                                    o.Dsn = "https://d42ddda84a6f4ffb8d9d66cb7d1a6d9b@o97031.ingest.sentry.io/6542291";
+                                });
+
+            builder.Logging.AddProvider(new SerilogLoggerProvider(loggingConfig.CreateLogger(), true));
 
             await builder.Build().RunAsync();
         }


### PR DESCRIPTION
Adds sentry using Serilog to wrap the default `ILogger` interface. DSN and api keys are already set, so this is ready to go.

Note the DSN has been restricted to `*.dragonfruit.network` to stop debug requests reaching the error list...