### PR TITLE
set fetch depth to 0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
         
       - id: sakura-deploy-key
         name: Get Deploy Token


### PR DESCRIPTION
should allow sentry release tagging extension to work properly