### PR TITLE
send latest as version if none provided

### DIFF
--- a/DragonFruit.Sakura/Network/Requests/ApiChangelogsRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/ApiChangelogsRequest.cs
@@ -10,7 +10,7 @@ namespace DragonFruit.Sakura.Network.Requests
         public ApiChangelogsRequest(string appName, string versionName)
         {
             AppName = appName;
-            VersionName = versionName;
+            VersionName = versionName ?? "latest";
         }
 
         public string AppName { get; }


### PR DESCRIPTION
fixes an error that occurs when a user selects an app from the changelogs list and it has no version information attached