### PR TITLE
change robots.txt 

### DIFF
--- a/DragonFruit.Sakura/wwwroot/robots.txt
+++ b/DragonFruit.Sakura/wwwroot/robots.txt
@@ -1,2 +1,2 @@
 ﻿User-Agent: *
-Disallow: *
+Disallow: /


### PR DESCRIPTION
should disable access entirely now, as preview.dragonfruit.network was showing up in search results on google