### PR TITLE
Improve menu layout on mobile devices

### DIFF
--- a/DragonFruit.Sakura/Common/PageHeader.razor
+++ b/DragonFruit.Sakura/Common/PageHeader.razor
@@ -1,9 +1,27 @@
-﻿<MudAppBar Color="@Background" Elevation="0" Bottom="true" Fixed="@Fixed" Class="sakura-sticky">
+﻿<MudAppBar Color="@Background" Elevation="0" Bottom="true" Fixed="@Fixed" Class="sakura-sticky" ToolBarClass="justify-content-between">
     <MudText Typo="Typo.h4" Style="font-size: 20px">@Title</MudText>
-    <MudSpacer/>
-    <MudStack Row="true" Spacing="2">
-        @ChildContent
-    </MudStack>
+
+    @* menu for small screens *@
+    <MudHidden Breakpoint="Breakpoint.MdAndUp">
+        <MudMenu Icon="@Icons.Rounded.Menu"
+                 DisableRipple="true"
+                 AnchorOrigin="Origin.TopLeft"
+                 TransformOrigin="Origin.BottomCenter"
+                 ActivationEvent="MouseEvent.LeftClick">
+            <ChildContent>
+                <MudStack Spacing="2" AlignItems="AlignItems.Start" Class="sakura-header-menu">
+                    @ChildContent
+                </MudStack>
+            </ChildContent>
+        </MudMenu>
+    </MudHidden>
+
+    @* default menu (stack) *@
+    <MudHidden Breakpoint="Breakpoint.SmAndDown">
+        <MudStack Row="true" Spacing="2">
+            @ChildContent
+        </MudStack>
+    </MudHidden>
 </MudAppBar>
 
 @code {

--- a/DragonFruit.Sakura/wwwroot/styles/global.css
+++ b/DragonFruit.Sakura/wwwroot/styles/global.css
@@ -57,3 +57,8 @@
     height: 75px;
     width: 75px;
 }
+
+.sakura-header-menu > .mud-button-root {
+    width: 100%;
+    justify-content: flex-start;
+}


### PR DESCRIPTION
Menus on `sm` displays will now show a menu icon that opens a menu with the content inside:

![image](https://user-images.githubusercontent.com/10289119/187907973-5ef744d0-92a0-46a2-8710-414e4f4e0fc8.png)
