### PR TITLE
add noscript warning

### DIFF
--- a/DragonFruit.Sakura/wwwroot/index.html
+++ b/DragonFruit.Sakura/wwwroot/index.html
@@ -36,6 +36,9 @@
     <div class="sakura-loading">
         <img src="/assets/dragonfruit.png" alt="DragonFruit Logo" height="100" width="100"/>
         <span>Loading...</span>
+        <noscript class="sakura-js-warning">
+            This site requires JavaScript to run. Please enable JavaScript or use a supported browser to continue.
+        </noscript>
     </div>
 </div>
 

--- a/DragonFruit.Sakura/wwwroot/styles/global.css
+++ b/DragonFruit.Sakura/wwwroot/styles/global.css
@@ -30,6 +30,12 @@ iframe {
     justify-content: center;
 }
 
+.sakura-js-warning {
+    text-align: center;
+    position: absolute;
+    bottom: 30px;
+}
+
 .sakura-sticky {
     position: -webkit-sticky;
     position: sticky;


### PR DESCRIPTION
Adds a js warning at the bottom of the loading screen if the user triggers the <noscript> tag (as seen below):

<img width="1912" alt="Screenshot 2022-10-18 at 14 24 50" src="https://user-images.githubusercontent.com/10289119/196442799-15afa157-7518-4fc9-b145-7946128a532c.png">
