### PR TITLE
Add IIS/Web Deploy support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,32 +4,58 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: write
+
 env:
   build-output: sakura-publish
 
 jobs:
-  deploy:
+  sentry-release:
     runs-on: ubuntu-latest
+
     environment:
       name: production
       url: https://dragonfruit.network/
-          
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_ORG: dragonfruit
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          projects: sakura
+          ignore_missing: true
+          version: ${{ github.ref_name }}
+
+  linux-container:
+    runs-on: ubuntu-latest
+
+    needs:
+      - sentry-release
+
+    environment:
+      name: production
+      url: https://dragonfruit.network/
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
 
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
+
       - name: Create build output folder
         run: mkdir ${{ env.build-output }}
 
@@ -56,13 +82,26 @@ jobs:
           platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           file: DragonFruit.Sakura.Host/Dockerfile
+  
+  windows-iis:
+    runs-on: windows-latest
+    
+    needs:
+      - sentry-release
 
-      - name: Create Sentry release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_ORG: dragonfruit
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    environment:
+      name: production
+      url: https://dragonfruit.network/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Program
+        run: dotnet publish -c Release -r win-x64 -p:Version=${{ github.ref_name }} -p:PublishProfile=Web.pubxml DragonFruit.Sakura.Host
+
+      - name: Archive Output
+        run: Compress-Archive -Path .\DragonFruit.Sakura.Host\bin\publish\* -DestinationPath Sakura-${{ github.ref_name }}.zip
+
+      - name: Upload Deploy Package
+        uses: softprops/action-gh-release@v1
         with:
-          projects: sakura
-          ignore_missing: true
-          version: ${{ github.ref_name }}
+          files: Sakura-${{ github.ref_name }}.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Program
-        run: dotnet publish -c Release -r win-x64 -p:Version=${{ github.ref_name }} -p:PublishProfile=Web.pubxml DragonFruit.Sakura.Host
+        run: dotnet publish -c Release -p:Version=${{ github.ref_name }} -p:PublishProfile=Web.pubxml DragonFruit.Sakura.Host
 
       - name: Archive Output
         run: Compress-Archive -Path .\DragonFruit.Sakura.Host\bin\publish\* -DestinationPath Sakura-${{ github.ref_name }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -184,8 +184,8 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
-*.publishproj
+# *.pubxml
+# *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
 # checkin your Azure Web App publish settings, but sensitive information contained

--- a/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
+++ b/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,13 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.5" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.11" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="Properties\launchSettings.json" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Sakura.Host/Properties/PublishProfiles/Web.pubxml
+++ b/DragonFruit.Sakura.Host/Properties/PublishProfiles/Web.pubxml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit http://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <_TargetId>IISWebDeployPackage</_TargetId>
+
+        <DeployIisAppPath>Sakura</DeployIisAppPath>
+        <WebPublishMethod>Package</WebPublishMethod>
+        <EnvironmentName>Production</EnvironmentName>
+        <ProjectGuid>99b15da3-9e63-4970-84b3-dff7948da6a5</ProjectGuid>
+
+        <LastUsedPlatform>Any CPU</LastUsedPlatform>
+        <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+
+        <ExcludeApp_Data>False</ExcludeApp_Data>
+        <PublishFramework>net7.0</PublishFramework>
+        <PackageAsSingleFile>true</PackageAsSingleFile>
+        <DesktopBuildPackageLocation>bin\publish\Sakura.zip</DesktopBuildPackageLocation>
+    </PropertyGroup>
+</Project>

--- a/DragonFruit.Sakura.Host/web.config
+++ b/DragonFruit.Sakura.Host/web.config
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <location path="." inheritInChildApplications="false">
+        <system.webServer>
+            <handlers>
+                <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+            </handlers>
+            <aspNetCore processPath=".\DragonFruit.Sakura.Host.exe" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess">
+            </aspNetCore>
+
+            <!-- add brotli/gzip compression support for wasm - see https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?view=aspnetcore-7.0#brotli-and-gzip-compression -->
+            <staticContent>
+                <remove fileExtension=".dll" />
+                <remove fileExtension=".json" />
+                <remove fileExtension=".woff" />
+                <remove fileExtension=".woff2" />
+                <remove fileExtension=".wasm" />
+                <mimeMap fileExtension=".json" mimeType="application/json" />
+                <mimeMap fileExtension=".woff" mimeType="font/woff" />
+                <mimeMap fileExtension=".woff2" mimeType="font/woff2" />
+                <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
+                <mimeMap fileExtension=".blat" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".js.gz" mimeType="application/javascript" />
+                <mimeMap fileExtension=".dat.gz" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".dll.gz" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".json.gz" mimeType="application/json" />
+                <mimeMap fileExtension=".wasm.gz" mimeType="application/wasm" />
+                <mimeMap fileExtension=".blat.gz" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".html.gz" mimeType="text/html" />
+                <mimeMap fileExtension=".css.gz" mimeType="text/css" />
+                <mimeMap fileExtension=".ico.gz" mimeType="image/x-icon" />
+                <mimeMap fileExtension=".svg.gz" mimeType="image/svg+xml" />
+                <mimeMap fileExtension=".js.br" mimeType="application/javascript" />
+                <mimeMap fileExtension=".dat.br" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".dll.br" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".json.br" mimeType="application/json" />
+                <mimeMap fileExtension=".wasm.br" mimeType="application/wasm" />
+                <mimeMap fileExtension=".blat.br" mimeType="application/octet-stream" />
+                <mimeMap fileExtension=".html.br" mimeType="text/html" />
+                <mimeMap fileExtension=".css.br" mimeType="text/css" />
+                <mimeMap fileExtension=".ico.br" mimeType="image/x-icon" />
+                <mimeMap fileExtension=".svg.br" mimeType="image/svg+xml" />
+            </staticContent>
+            <httpCompression>
+                <dynamicTypes>
+                    <remove mimeType="text/*" />
+                    <remove mimeType="application/javascript" />
+                    <remove mimeType="image/svg+xml" />
+                </dynamicTypes>
+                <staticTypes>
+                    <remove mimeType="text/*" />
+                    <remove mimeType="application/javascript" />
+                    <remove mimeType="image/svg+xml" />
+                </staticTypes>
+            </httpCompression>
+            <rewrite>
+                <outboundRules rewriteBeforeCache="true">
+                    <rule name="Add Vary Accept-Encoding" preCondition="PreCompressedFile" enabled="true">
+                        <match serverVariable="RESPONSE_Vary" pattern=".*" />
+                        <action type="Rewrite" value="Accept-Encoding" />
+                    </rule>
+                    <rule name="Add Encoding Brotli" preCondition="PreCompressedBrotli" enabled="true" stopProcessing="true">
+                        <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+                        <action type="Rewrite" value="br" />
+                    </rule>
+                    <rule name="Add Encoding Gzip" preCondition="PreCompressedGzip" enabled="true" stopProcessing="true">
+                        <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+                        <action type="Rewrite" value="gzip" />
+                    </rule>
+                    <preConditions>
+                        <preCondition name="PreCompressedFile">
+                            <add input="{HTTP_URL}" pattern="\.(gz|br)$" />
+                        </preCondition>
+                        <preCondition name="PreCompressedBrotli">
+                            <add input="{HTTP_URL}" pattern="\.br$" />
+                        </preCondition>
+                        <preCondition name="PreCompressedGzip">
+                            <add input="{HTTP_URL}" pattern="\.gz$" />
+                        </preCondition>
+                    </preConditions>
+                </outboundRules>
+                <rules>
+                    <rule name="Rewrite brotli file" stopProcessing="true">
+                        <match url="(.*)"/>
+                        <conditions>
+                            <add input="{HTTP_ACCEPT_ENCODING}" pattern="br" />
+                            <add input="{REQUEST_FILENAME}" pattern="\.(js|dat|dll|json|wasm|blat|htm|html|css|ico|svg)$" />
+                            <add input="{REQUEST_FILENAME}.br" matchType="IsFile" />
+                        </conditions>
+                        <action type="Rewrite" url="{R:1}.br" />
+                    </rule>
+                    <rule name="Rewrite gzip file" stopProcessing="true">
+                        <match url="(.*)"/>
+                        <conditions>
+                            <add input="{HTTP_ACCEPT_ENCODING}" pattern="gzip" />
+                            <add input="{REQUEST_FILENAME}" pattern="\.(js|dat|dll|json|wasm|blat|htm|html|css|ico|svg)$" />
+                            <add input="{REQUEST_FILENAME}.gz" matchType="IsFile" />
+                        </conditions>
+                        <action type="Rewrite" url="{R:1}.gz" />
+                    </rule>
+                </rules>
+            </rewrite>
+        </system.webServer>
+    </location>
+</configuration>
+<!--ProjectGuid: -->

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Markdig" Version="0.33.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.11" />
-        <PackageReference Include="MudBlazor" Version="6.10.0" />
+        <PackageReference Include="MudBlazor" Version="6.1.9" />
         <PackageReference Include="Sentry.Serilog" Version="3.39.1" />
         <PackageReference Include="Serilog" Version="3.0.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -15,14 +15,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2023.210.0" />
-        <PackageReference Include="DragonFruit.Data.Serializers.SystemJson" Version="2023.210.0" />
-        <PackageReference Include="Markdig" Version="0.31.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.5" />
-        <PackageReference Include="MudBlazor" Version="6.1.9" />
-        <PackageReference Include="Sentry.Serilog" Version="3.31.0" />
-        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="DragonFruit.Data" Version="2023.727.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.SystemJson" Version="2023.727.0" />
+        <PackageReference Include="Markdig" Version="0.33.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.11" />
+        <PackageReference Include="MudBlazor" Version="6.10.0" />
+        <PackageReference Include="Sentry.Serilog" Version="3.39.1" />
+        <PackageReference Include="Serilog" Version="3.0.1" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
         <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0" />
         <PackageReference Include="SharpYaml" Version="2.1.0" />


### PR DESCRIPTION
Adds tags needed for IIS InProcess hosting to work, along with a preset web.config file that optimises serving brotli/gzip static files (bypasses the main pipeline for even faster processing)

Updates all dependencies and changes the workflow to produce both a linux build and a windows edition.