### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,16 +2,16 @@
   "version": 1,
   "isRoot": true,
   "tools": {
+    "jetbrains.resharper.globaltools": {
+      "version": "2023.3.1",
+      "commands": [
+        "jb"
+      ]
+    },
     "nvika": {
       "version": "3.0.0",
       "commands": [
         "nvika"
-      ]
-    },
-    "jetbrains.resharper.globaltools": {
-      "version": "2022.1.2",
-      "commands": [
-        "jb"
       ]
     }
   }

--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -1,23 +1,26 @@
 name: Code Quality
+
 on:
-  pull_request: { }
+  pull_request:
+    branches: master
   push:
-    branches:
-      - master
+    branches: master
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: false
 
 jobs:
   quality:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-            
-      - name: Install .NET
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.0.x
-            7.0.x
+            8.0.x
 
       - name: Restore Tools
         run: dotnet tool restore
@@ -25,8 +28,8 @@ jobs:
       - name: Restore Packages
         run: dotnet restore
 
-      - name: Run InspectCode
-        run: dotnet jb inspectcode ${{github.workspace}}/DragonFruit.Sakura.sln --exclude="**/wwwroot/**.*" --exclude="**/*.razor" --output=${{github.workspace}}/inspectcodereport.xml --cachesDir=${{github.workspace}}/inspectcode --verbosity=WARN --no-build
+      - name: InspectCode
+        run: dotnet jb inspectcode DragonFruit.Sakura.sln --exclude="**/wwwroot/**.*" --exclude="**/*.razor" --output=inspectcodereport.xml --cachesDir=inspectcode --verbosity=WARN --no-build
 
-      - name: Run NVika
-        run: dotnet nvika parsereport "${{github.workspace}}/inspectcodereport.xml"
+      - name: NVika
+        run: dotnet nvika parsereport inspectcodereport.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [ published ]
 
-permissions:
-  contents: write
-
 env:
   build-output: sakura-publish
 
@@ -19,7 +16,7 @@ jobs:
       url: https://dragonfruit.network/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -33,58 +30,32 @@ jobs:
           ignore_missing: true
           version: ${{ github.ref_name }}
 
-  linux-container:
+  website-package:
     runs-on: ubuntu-latest
-
-    needs:
-      - sentry-release
-
-    environment:
-      name: production
-      url: https://dragonfruit.network/
+    
+    permissions: 
+      packages: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.x'
-
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create build output folder
-        run: mkdir ${{ env.build-output }}
-
-      - name: Restore NuGet Packages
-        run: dotnet restore
-
-      - name: Build Project
-        run: dotnet publish -c Release -o ${{ env.build-output }} -p:Version=${{ github.ref_name }} DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
-
-      - id: meta
-        name: Create metadata
-        uses: docker/metadata-action@v4
-        with:
-          images: dragonfruitdotnet/website
-          tags: |
-            type=raw,value=latest
-            type=ref,event=tag
-
-      - name: Dockerise
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          context: ${{ env.build-output }}
-          platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          file: DragonFruit.Sakura.Host/Dockerfile
+          dotnet-version: '8.0.x'
+          
+      - name: Build Program
+        run: dotnet publish -c Release -p:Version=${{ github.event.release.tag_name }} DragonFruit.Sakura
+        
+      - name: Package Output
+        run: dotnet pack -c Release -p:Version=${{ github.event.inputs.version }} -o ./packages --no-build DragonFruit.Sakura
+        
+      - name: Upload Package
+        run: dotnet nuget push -s https://nuget.pkg.github.com/dragonfruitnetwork/index.json -k ${{ github.token }} ./packages/*.nupkg
   
   windows-iis:
     runs-on: windows-latest
+    
+    permissions:
+      contents: write
     
     needs:
       - sentry-release
@@ -94,14 +65,18 @@ jobs:
       url: https://dragonfruit.network/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build Program
-        run: dotnet publish -c Release -p:Version=${{ github.ref_name }} -p:PublishProfile=Web.pubxml DragonFruit.Sakura.Host
+        run: dotnet publish -c Release -p:Version=${{ github.event.release.tag_name }} -p:PublishProfile=Web.pubxml DragonFruit.Sakura.Host
 
       - name: Archive Output
-        run: Compress-Archive -Path .\DragonFruit.Sakura.Host\bin\publish\* -DestinationPath Sakura-${{ github.ref_name }}.zip
+        run: Compress-Archive -Path .\DragonFruit.Sakura.Host\bin\publish\* -DestinationPath Sakura-${{ github.event.release.tag_name }}.zip
 
       - name: Upload Deploy Package
         uses: softprops/action-gh-release@v1
         with:
-          files: Sakura-${{ github.ref_name }}.zip
+          files: Sakura-${{ github.event.release.tag_name }}.zip

--- a/DragonFruit.Sakura.Host/Dockerfile
+++ b/DragonFruit.Sakura.Host/Dockerfile
@@ -1,8 +1,0 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
-WORKDIR /app
-
-ADD . .
-EXPOSE 80
-ENV ASPNETCORE_URLS http://+:80
-
-ENTRYPOINT ["dotnet", "DragonFruit.Sakura.Host.dll"]

--- a/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
+++ b/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
@@ -11,9 +11,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.11" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+      <PackageReference Include="Sentry.Extensions.Logging" Version="3.41.3" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
+++ b/DragonFruit.Sakura.Host/DragonFruit.Sakura.Host.csproj
@@ -14,7 +14,6 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
       <PackageReference Include="Sentry.Extensions.Logging" Version="3.41.3" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Sakura.Host/Host.cshtml
+++ b/DragonFruit.Sakura.Host/Host.cshtml
@@ -31,9 +31,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@fortawesome/fontawesome-free@6.1.1/css/all.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap-utilities.min.css"/>
 
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.26.0/prism.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.26.0/components/prism-csharp.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.26.0/components/prism-cshtml.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-csharp.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-cshtml.min.js" defer></script>
 
     <script src="~/_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
 </head>

--- a/DragonFruit.Sakura.Host/Program.cs
+++ b/DragonFruit.Sakura.Host/Program.cs
@@ -30,7 +30,7 @@ namespace DragonFruit.Sakura.Host
                    {
                        o.SingleLine = true;
                        o.IncludeScopes = false;
-                       o.TimestampFormat = $"[dd/MM/yyyy hh:mm:ss] ";
+                       o.TimestampFormat = "[dd/MM/yyyy hh:mm:ss] ";
                    })
                    .AddSentry(o =>
                    {

--- a/DragonFruit.Sakura.Host/Program.cs
+++ b/DragonFruit.Sakura.Host/Program.cs
@@ -8,15 +8,13 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MudBlazor.Services;
-using Serilog;
-using Serilog.Events;
-using Serilog.Sinks.SystemConsole.Themes;
+using Sentry;
 
 namespace DragonFruit.Sakura.Host
 {
     public static class Program
     {
-        public static async Task Main(string[] args)
+        public static Task Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
 
@@ -27,21 +25,24 @@ namespace DragonFruit.Sakura.Host
             // enable _content files
             builder.WebHost.UseStaticWebAssets();
 
-            builder.Logging.ClearProviders();
-            builder.Logging.AddSerilog(new LoggerConfiguration()
-                                       .MinimumLevel.Debug()
-                                       .WriteTo.Console(theme: AnsiConsoleTheme.Literate)
-                                       .WriteTo.Sentry(o =>
-                                       {
-                                           o.Dsn = builder.Configuration["Sentry:Dsn"];
+            builder.Logging.ClearProviders()
+                   .AddSimpleConsole(o =>
+                   {
+                       o.SingleLine = true;
+                       o.IncludeScopes = false;
+                       o.TimestampFormat = $"[dd/MM/yyyy hh:mm:ss] ";
+                   })
+                   .AddSentry(o =>
+                   {
+                       o.Dsn = builder.Configuration["Sentry:Dsn"];
+                       o.Release = Assembly.GetExecutingAssembly().GetName().Version!.ToString(3);
 
-                                           o.MaxBreadcrumbs = 50;
-                                           o.MinimumEventLevel = LogEventLevel.Error;
-                                           o.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                       o.MaxBreadcrumbs = 50;
+                       o.MinimumEventLevel = LogLevel.Error;
+                       o.MinimumBreadcrumbLevel = LogLevel.Debug;
 
-                                           var version = Assembly.GetExecutingAssembly().GetName().Version;
-                                           o.Release = version?.ToString(version.Build > 0 ? 3 : 2);
-                                       }).CreateLogger(), true);
+                       o.DisableUnobservedTaskExceptionCapture();
+                   });
 
             builder.Services.AddApiAuthorization();
             builder.Services.AddHttpContextAccessor();
@@ -62,7 +63,7 @@ namespace DragonFruit.Sakura.Host
             app.MapFallbackToController("Host", "Blazor");
             app.MapFallbackToController("/changelogs/{app}/{version}", "Host", "Blazor");
 
-            await app.RunAsync().ConfigureAwait(false);
+            return app.RunAsync();
         }
     }
 }

--- a/DragonFruit.Sakura.sln.DotSettings
+++ b/DragonFruit.Sakura.sln.DotSettings
@@ -364,6 +364,7 @@ Licensed under GNU AGPLv3. Refer to the LICENSE file for more info</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MMR/@EntryIndexedValue">MMR</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/DragonFruit.Sakura/Administration/Index.razor
+++ b/DragonFruit.Sakura/Administration/Index.razor
@@ -2,6 +2,7 @@
 @using DragonFruit.Sakura.Network
 @layout AdminLayout
 
+<PageTitle>Admin &middot; DragonFruit Network</PageTitle>
 <MudContainer MaxWidth="MaxWidth.Large">
     <MudStack>
         <MudPaper Elevation="0" Class="p-4">

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Markdig" Version="0.34.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" />
-        <PackageReference Include="MudBlazor" Version="6.1.9" />
+        <PackageReference Include="MudBlazor" Version="6.11.1" />
         <PackageReference Include="Sentry.Extensions.Logging" Version="3.41.3" />
         <PackageReference Include="SharpYaml" Version="2.1.0" />
     </ItemGroup>

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -7,6 +7,13 @@
     </PropertyGroup>
     
     <PropertyGroup>
+        <Title>DragonFruit Sakura</Title>
+        <Authors>DragonFruit Network</Authors>
+        <Copyright>Copyright (c) DragonFruit Network</Copyright>
+        <Description>The face of DragonFruit Network</Description>
+    </PropertyGroup>
+    
+    <PropertyGroup>
         <PackageIcon>icon.png</PackageIcon>
         <PackageId>DragonFruit.Sakura</PackageId>
         <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
@@ -15,16 +15,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2023.727.0" />
-        <PackageReference Include="DragonFruit.Data.Serializers.SystemJson" Version="2023.727.0" />
-        <PackageReference Include="Markdig" Version="0.33.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.11" />
+        <PackageReference Include="DragonFruit.Data" Version="0.9.3-beta" />
+        <PackageReference Include="DragonFruit.Data.Roslyn" Version="0.9.3-beta" PrivateAssets="all" />
+        <PackageReference Include="Markdig" Version="0.34.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" />
         <PackageReference Include="MudBlazor" Version="6.1.9" />
-        <PackageReference Include="Sentry.Serilog" Version="3.39.1" />
-        <PackageReference Include="Serilog" Version="3.0.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-        <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="1.0.0" />
+        <PackageReference Include="Sentry.Extensions.Logging" Version="3.41.3" />
+        <PackageReference Include="Sentry.Serilog" Version="3.41.3" />
+        <PackageReference Include="Serilog" Version="3.1.1" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="2.0.0" />
         <PackageReference Include="SharpYaml" Version="2.1.0" />
     </ItemGroup>
 

--- a/DragonFruit.Sakura/DragonFruit.Sakura.csproj
+++ b/DragonFruit.Sakura/DragonFruit.Sakura.csproj
@@ -22,10 +22,6 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" />
         <PackageReference Include="MudBlazor" Version="6.1.9" />
         <PackageReference Include="Sentry.Extensions.Logging" Version="3.41.3" />
-        <PackageReference Include="Sentry.Serilog" Version="3.41.3" />
-        <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-        <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="2.0.0" />
         <PackageReference Include="SharpYaml" Version="2.1.0" />
     </ItemGroup>
 

--- a/DragonFruit.Sakura/Network/Requests/AdminApiAppsListingRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiAppsListingRequest.cs
@@ -3,9 +3,10 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiAppsListingRequest : YunaApiRequest
+    public partial class AdminApiAppsListingRequest : YunaApiRequest
     {
         protected override string Stub => "/apps";
-        protected override bool RequireAuth => true;
+
+        protected internal override bool RequiresAuthentication => true;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationCreationRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationCreationRequest.cs
@@ -1,30 +1,21 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogModificationCreationRequest : YunaApiRequest
+    public partial class AdminApiChangelogModificationCreationRequest(string appId, string version, ApiChangelogModification modification) : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Post;
         protected override string Stub => $"/{AppId}/changelogs/{Version}/modifications";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Post;
-        protected override BodyType BodyType => BodyType.SerializedProperty;
+        protected internal override bool RequiresAuthentication => true;
 
-        public AdminApiChangelogModificationCreationRequest(string appId, string version, ApiChangelogModification modification)
-        {
-            AppId = appId;
-            Version = version;
-            Modification = modification;
-        }
-
-        public string AppId { get; }
-        public string Version { get; }
+        public string AppId { get; } = appId;
+        public string Version { get; } = version;
 
         [RequestBody]
-        public ApiChangelogModification Modification { get; }
+        public ApiChangelogModification Modification { get; } = modification;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationDeletionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationDeletionRequest.cs
@@ -1,26 +1,17 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogModificationDeletionRequest : YunaApiRequest
+    public partial class AdminApiChangelogModificationDeletionRequest(string appId, string version, int modificationId) : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Delete;
         protected override string Stub => $"/{AppId}/changelogs/{Version}/modifications/{ModificationId}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Delete;
+        protected internal override bool RequiresAuthentication => true;
 
-        public AdminApiChangelogModificationDeletionRequest(string appId, string version, int modificationId)
-        {
-            AppId = appId;
-            Version = version;
-            ModificationId = modificationId;
-        }
-
-        public string AppId { get; }
-        public string Version { get; }
-        public int ModificationId { get; }
+        public string AppId { get; } = appId;
+        public string Version { get; } = version;
+        public int ModificationId { get; } = modificationId;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationEditRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogModificationEditRequest.cs
@@ -1,18 +1,16 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogModificationEditRequest : YunaApiRequest
+    public partial class AdminApiChangelogModificationEditRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Patch;
         protected override string Stub => $"/{AppId}/changelogs/{Version}/modifications/{Modification.Id}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Patch;
-        protected override BodyType BodyType => BodyType.SerializedProperty;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiChangelogModificationEditRequest(string appId, string version, ApiChangelogModification modification)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogVersionListingRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogVersionListingRequest.cs
@@ -3,10 +3,9 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogVersionListingRequest : YunaApiRequest
+    public partial class AdminApiChangelogVersionListingRequest : YunaApiRequest
     {
         protected override string Stub => $"/{AppId}/changelogs/list";
-        protected override bool RequireAuth => true;
 
         public AdminApiChangelogVersionListingRequest(string appId)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogsCreationRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogsCreationRequest.cs
@@ -1,28 +1,20 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogsCreationRequest : YunaApiRequest
+    public partial class AdminApiChangelogsCreationRequest(string appId, ApiChangelogRelease release) : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Post;
         protected override string Stub => $"/{AppId}/changelogs";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Post;
-        protected override BodyType BodyType => BodyType.SerializedProperty;
+        protected internal override bool RequiresAuthentication => true;
 
-        public AdminApiChangelogsCreationRequest(string appId, ApiChangelogRelease release)
-        {
-            AppId = appId;
-            Release = release;
-        }
-
-        public string AppId { get; }
+        public string AppId { get; } = appId;
 
         [RequestBody]
-        public ApiChangelogRelease Release { get; }
+        public ApiChangelogRelease Release { get; } = release;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiChangelogsDeletionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiChangelogsDeletionRequest.cs
@@ -1,24 +1,16 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiChangelogsDeletionRequest : YunaApiRequest
+    public partial class AdminApiChangelogsDeletionRequest(string appId, string versionName) : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Delete;
         protected override string Stub => $"/{AppId}/changelogs/{VersionName}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Delete;
+        protected internal override bool RequiresAuthentication => true;
 
-        public AdminApiChangelogsDeletionRequest(string appId, string versionName)
-        {
-            AppId = appId;
-            VersionName = versionName;
-        }
-
-        public string AppId { get; }
-        public string VersionName { get; }
+        public string AppId { get; } = appId;
+        public string VersionName { get; } = versionName;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionActiveReleaseRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionActiveReleaseRequest.cs
@@ -1,17 +1,16 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionActiveReleaseRequest : YunaApiRequest
+    public partial class AdminApiDistributionActiveReleaseRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Put;
         protected override string Stub => $"/{AppId}/dist/{BranchName}/releases/active";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Put;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiDistributionActiveReleaseRequest(string appId, string branchName, int activeReleaseId)
         {
@@ -23,10 +22,10 @@ namespace DragonFruit.Sakura.Network.Requests
         public string AppId { get; }
         public string BranchName { get; }
 
-        [FormParameter("release_id")]
+        [RequestParameter(ParameterType.Form, "release_id")]
         public int ActiveReleaseId { get; }
 
-        [FormParameter("force")]
+        [RequestParameter(ParameterType.Form, "force")]
         protected bool Force => true;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchCreationRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchCreationRequest.cs
@@ -1,27 +1,20 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionBranchCreationRequest : YunaApiRequest
+    public partial class AdminApiDistributionBranchCreationRequest(string appId, string branchName) : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Post;
         protected override string Stub => $"/{AppId}/dist/branches";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Post;
+        protected internal override bool RequiresAuthentication => true;
 
-        public AdminApiDistributionBranchCreationRequest(string appId, string branchName)
-        {
-            AppId = appId;
-            BranchName = branchName;
-        }
+        public string AppId { get; } = appId;
 
-        public string AppId { get; }
-
-        [FormParameter("name")]
-        public string BranchName { get; }
+        [RequestParameter(ParameterType.Form, "name")]
+        public string BranchName { get; } = branchName;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchDeletionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchDeletionRequest.cs
@@ -1,16 +1,14 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionBranchDeletionRequest : YunaApiRequest
+    public partial class AdminApiDistributionBranchDeletionRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Delete;
         protected override string Stub => $"/{AppId}/dist/branches/{BranchName}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Delete;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiDistributionBranchDeletionRequest(string appId, string branchName)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchRequest.cs
@@ -3,10 +3,11 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionBranchRequest : YunaApiRequest
+    public partial class AdminApiDistributionBranchRequest : YunaApiRequest
     {
         protected override string Stub => $"/{AppId}/dist/{BranchName}";
-        protected override bool RequireAuth => true;
+
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiDistributionBranchRequest(string appId, string branchName)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchesRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionBranchesRequest.cs
@@ -3,10 +3,11 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionBranchesRequest : YunaApiRequest
+    public partial class AdminApiDistributionBranchesRequest : YunaApiRequest
     {
         protected override string Stub => $"/{AppId}/dist/branches";
-        protected override bool RequireAuth => true;
+
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiDistributionBranchesRequest(string appId)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiDistributionReleaseDeletionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiDistributionReleaseDeletionRequest.cs
@@ -1,16 +1,14 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiDistributionReleaseDeletionRequest : YunaApiRequest
+    public partial class AdminApiDistributionReleaseDeletionRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Delete;
         protected override string Stub => $"/{AppId}/dist/{BranchName}/releases/{ReleaseId}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Delete;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiDistributionReleaseDeletionRequest(string appId, string branchName, int releaseId)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiKeychainAdditionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiKeychainAdditionRequest.cs
@@ -1,17 +1,17 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiKeychainAdditionRequest : YunaApiRequest
+    [FormBodyType(FormBodyType.Multipart)]
+    public partial class AdminApiKeychainAdditionRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Post;
         protected override string Stub => "/users/me/keychain";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Post;
-        protected override BodyType BodyType => BodyType.Custom;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiKeychainAdditionRequest(Stream pemFile, DateTime? expiry)
         {
@@ -19,23 +19,10 @@ namespace DragonFruit.Sakura.Network.Requests
             Expiry = expiry;
         }
 
+        [RequestParameter(ParameterType.Form, "pem")]
         public Stream PublicKey { get; }
+
+        [RequestParameter(ParameterType.Form, "expiry")]
         public DateTime? Expiry { get; }
-
-        protected override HttpContent BodyContent
-        {
-            get
-            {
-                var multipartBody = new MultipartFormDataContent();
-                multipartBody.Add(new StreamContent(PublicKey), "pem", "file.pem");
-
-                if (Expiry.HasValue)
-                {
-                    multipartBody.Add(new StringContent(Expiry.Value.ToString("O")), "expiry");
-                }
-
-                return multipartBody;
-            }
-        }
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/AdminApiKeychainDeletionRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiKeychainDeletionRequest.cs
@@ -1,16 +1,14 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data;
-
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiKeychainDeletionRequest : YunaApiRequest
+    public partial class AdminApiKeychainDeletionRequest : YunaApiRequest
     {
+        public override HttpMethod RequestMethod => HttpMethod.Delete;
         protected override string Stub => $"/users/me/keychain/{KeyId}";
-        protected override bool RequireAuth => true;
 
-        protected override Methods Method => Methods.Delete;
+        protected internal override bool RequiresAuthentication => true;
 
         public AdminApiKeychainDeletionRequest(string keyId)
         {

--- a/DragonFruit.Sakura/Network/Requests/AdminApiKeychainListingRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/AdminApiKeychainListingRequest.cs
@@ -1,19 +1,19 @@
 ﻿// DragonFruit Sakura Copyright (c) DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
-using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class AdminApiKeychainListingRequest : YunaApiRequest
+    public partial class AdminApiKeychainListingRequest : YunaApiRequest
     {
         protected override string Stub => "/users/me/keychain";
-        protected override bool RequireAuth => true;
+        protected internal override bool RequiresAuthentication => true;
 
-        [QueryParameter("offset")]
+        [RequestParameter(ParameterType.Query, "offset")]
         public int? Offset { get; set; }
 
-        [QueryParameter("limit")]
+        [RequestParameter(ParameterType.Query, "limit")]
         public int? Limit { get; set; }
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/ApiChangelogsRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/ApiChangelogsRequest.cs
@@ -3,17 +3,11 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class ApiChangelogsRequest : YunaApiRequest
+    public partial class ApiChangelogsRequest(string appId, string versionName) : YunaApiRequest
     {
         protected override string Stub => $"/{AppId}/changelogs/{VersionName}";
 
-        public ApiChangelogsRequest(string appId, string versionName)
-        {
-            AppId = appId;
-            VersionName = versionName ?? "latest";
-        }
-
-        public string AppId { get; }
-        public string VersionName { get; }
+        public string AppId { get; } = appId;
+        public string VersionName { get; } = versionName ?? "latest";
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/ApiDefaultChangelogsRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/ApiDefaultChangelogsRequest.cs
@@ -3,7 +3,7 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class ApiDefaultChangelogsRequest : YunaApiRequest
+    public partial class ApiDefaultChangelogsRequest : YunaApiRequest
     {
         protected override string Stub => "/changelogs/latest";
     }

--- a/DragonFruit.Sakura/Network/Requests/ApiGeolocationInfoRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/ApiGeolocationInfoRequest.cs
@@ -3,7 +3,7 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class ApiGeolocationInfoRequest : YunaApiRequest
+    public partial class ApiGeolocationInfoRequest : YunaApiRequest
     {
         protected override string Stub => "/onionfruit/status";
     }

--- a/DragonFruit.Sakura/Network/Requests/ApiWikiPageRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/ApiWikiPageRequest.cs
@@ -3,15 +3,10 @@
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class ApiWikiPageRequest : YunaApiRequest
+    public partial class ApiWikiPageRequest(string pagePath) : YunaApiRequest
     {
         protected override string Stub => $"/wiki/en/{PagePath?.TrimStart('/')}";
 
-        public ApiWikiPageRequest(string pagePath)
-        {
-            PagePath = pagePath;
-        }
-
-        public string PagePath { get; }
+        public string PagePath { get; } = pagePath;
     }
 }

--- a/DragonFruit.Sakura/Network/Requests/OnionCountryInfoRequest.cs
+++ b/DragonFruit.Sakura/Network/Requests/OnionCountryInfoRequest.cs
@@ -5,8 +5,8 @@ using DragonFruit.Data;
 
 namespace DragonFruit.Sakura.Network.Requests
 {
-    public class OnionCountryInfoRequest : ApiRequest
+    public partial class OnionCountryInfoRequest : ApiRequest
     {
-        public override string Path => "https://onioncdn.dragonfruit.network/country-details.json";
+        public override string RequestPath => "https://onioncdn.dragonfruit.network/country-details.json";
     }
 }

--- a/DragonFruit.Sakura/Network/SakuraClient.cs
+++ b/DragonFruit.Sakura/Network/SakuraClient.cs
@@ -2,25 +2,14 @@
 // Licensed under GNU AGPLv3. Refer to the LICENSE file for more info
 
 using DragonFruit.Data;
-using DragonFruit.Data.Serializers.SystemJson;
-using DragonFruit.Sakura.Network.Requests;
+using DragonFruit.Data.Serializers;
 
 namespace DragonFruit.Sakura.Network
 {
-    public abstract class SakuraClient : ApiClient<ApiSystemTextJsonSerializer>
+    public abstract class SakuraClient : ApiClient<ApiJsonSerializer>
     {
         public abstract bool IsServerSide { get; }
 
-        protected virtual string ApiBaseUrl => "https://api.dragonfruit.network";
-
-        protected override Task ValidateRequest(ApiRequest request)
-        {
-            if (request is YunaApiRequest yunaApiRequest && yunaApiRequest.BaseUrlOverride == null)
-            {
-                yunaApiRequest.BaseUrlOverride = ApiBaseUrl;
-            }
-
-            return base.ValidateRequest(request);
-        }
+        protected internal virtual string ApiBaseUrl => "https://api.dragonfruit.network";
     }
 }

--- a/DragonFruit.Sakura/Wiki/Wiki.razor
+++ b/DragonFruit.Sakura/Wiki/Wiki.razor
@@ -88,7 +88,7 @@ else
                                     <MudAvatarGroup Max="5" Spacing="2">
                                         @foreach (var author in PageMetadata.Authors)
                                         {
-                                            <MudAvatar Image="@author.AvatarUrl" Size="Size.Small" Style="align-items: unset">
+                                            <MudAvatar Image="@author.AvatarUrl" Size="Size.Small">
                                                 @(string.IsNullOrEmpty(author.AvatarUrl) ? char.ToUpperInvariant(author.Username[0]) : null)
                                             </MudAvatar>
                                         }

--- a/DragonFruit.Sakura/Wiki/Wiki.razor
+++ b/DragonFruit.Sakura/Wiki/Wiki.razor
@@ -70,13 +70,13 @@ else
                     }
 
                     <div id="wiki-content">
-                        @PageContent.Content
+                        @PageContent?.Content
                     </div>
 
                     @if (PageMetadata != null)
                     {
                         <MudSpacer/>
-                        <MudDivider/>
+                        <MudDivider DividerType="DividerType.FullWidth" FlexItem="true" Style="flex-grow: 0"/>
 
                         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3" Class="flex-wrap-reverse">
                             <MudTooltip Text="@PageMetadata.LastCommitMessage" Placement="Placement.End">
@@ -88,7 +88,9 @@ else
                                     <MudAvatarGroup Max="5" Spacing="2">
                                         @foreach (var author in PageMetadata.Authors)
                                         {
-                                            <MudAvatar Image="@author.AvatarUrl" Size="Size.Small">@author.Username[0]</MudAvatar>
+                                            <MudAvatar Image="@author.AvatarUrl" Size="Size.Small" Style="align-items: unset">
+                                                @(string.IsNullOrEmpty(author.AvatarUrl) ? char.ToUpperInvariant(author.Username[0]) : null)
+                                            </MudAvatar>
                                         }
                                     </MudAvatarGroup>
                                 </MudTooltip>

--- a/DragonFruit.Sakura/Wiki/Wiki.razor
+++ b/DragonFruit.Sakura/Wiki/Wiki.razor
@@ -19,7 +19,7 @@ else
 
     <link rel="stylesheet" href="/styles/wiki.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jetbrains-mono@1.0.6/css/jetbrains-mono.css"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.26.0/themes/prism-tomorrow.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css"/>
 </HeadContent>
 
 <GlobalNavigation/>

--- a/DragonFruit.Sakura/Wiki/Wiki.razor.cs
+++ b/DragonFruit.Sakura/Wiki/Wiki.razor.cs
@@ -94,12 +94,12 @@ namespace DragonFruit.Sakura.Wiki
 
             if (pathSegments is null || !pathSegments.Any())
             {
-                return new List<BreadcrumbItem> { homeSegment };
+                return [homeSegment];
             }
 
             // split the url into a set of segments representing the location of each page (i.e. the topmost page has to include all the parents)
             var segmentArrays = Enumerable.Range(1, pathSegments.Length).Select(i => new ArraySegment<string>(pathSegments, 0, i));
-            return segmentArrays.Select(x => new BreadcrumbItem(x.Last(), $"/wiki/{string.Join("/", x)}")).Prepend(homeSegment).ToList();
+            return segmentArrays.Select(x => new BreadcrumbItem(x.Last(), $"/wiki/{string.Join("/", x)}")).ToList();
         }
     }
 }

--- a/DragonFruit.Sakura/Wiki/Wiki.razor.cs
+++ b/DragonFruit.Sakura/Wiki/Wiki.razor.cs
@@ -99,7 +99,7 @@ namespace DragonFruit.Sakura.Wiki
 
             // split the url into a set of segments representing the location of each page (i.e. the topmost page has to include all the parents)
             var segmentArrays = Enumerable.Range(1, pathSegments.Length).Select(i => new ArraySegment<string>(pathSegments, 0, i));
-            return segmentArrays.Select(x => new BreadcrumbItem(x.Last(), $"/wiki/{string.Join("/", x)}")).ToList();
+            return segmentArrays.Select(x => new BreadcrumbItem(x.Last(), $"/{string.Join("/", x)}")).ToList();
         }
     }
 }

--- a/DragonFruit.Sakura/wwwroot/styles/global.css
+++ b/DragonFruit.Sakura/wwwroot/styles/global.css
@@ -11,6 +11,8 @@ iframe {
 
 .sakura-hero, .sakura-full-height-section {
     min-height: 100vh;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 .sakura-full-height-section {

--- a/DragonFruit.Sakura/wwwroot/styles/overrides.css
+++ b/DragonFruit.Sakura/wwwroot/styles/overrides.css
@@ -1,3 +1,7 @@
 ﻿.mud-button {
     text-transform: none !important;
 }
+
+.mud-avatar {
+    align-items: unset !important;
+}


### PR DESCRIPTION
Upgrades the website to .NET 8 and updates dependencies:

- Uses the new source generator and DragonFruit.Data package, updating requests and clients
- Removes serilog, replacing it with microsoft logging libraries
- Updates MudBlazor, applying patches to fix issues with avatar scaling
- Fixes an issue with wiki breadcrumbs not linking to the correct location
- Updates workflow to use .NET 8
- Remove Docker image and replace with embeddable nuget package